### PR TITLE
docs(readme): fix markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,43 +5,50 @@ Copy-paste friendly stability badges from the [beautiful iojs docs](https://iojs
 ## Stability: 0 - Deprecated
 
 [![deprecated][deprecated-img]][stability-url]
+
 [deprecated-img]: https://img.shields.io/badge/stability-0%20--%20deprecated-red.svg?style=flat-square
 
 ```md
 [![deprecated][deprecated-img]][stability-url]
+
 [deprecated-img]: https://img.shields.io/badge/stability-0%20--%20deprecated-red.svg?style=flat-square
 [stability-url]: https://iojs.org/api/documentation.html#documentation_stability_index
 ```
 ## Stability: 1 - Experimental
 
 [![experimental][experimental-img]][stability-url]
+
 [experimental-img]: https://img.shields.io/badge/stability-1%20--%20experimental-orange.svg?style=flat-square
 
 ```md
 [![experimental][experimental-img]][stability-url]
+
 [experimental-img]: https://img.shields.io/badge/stability-1%20--%20experimental-orange.svg?style=flat-square
 [stability-url]: https://iojs.org/api/documentation.html#documentation_stability_index
 ```
 ## Stability: 2 - Stable
 
 [![stable][stable-img]][stability-url]
+
 [stable-img]: https://img.shields.io/badge/stability-2%20--%20stable-brightgreen.svg?style=flat-square
 
 ```md
 [![stable][stable-img]][stability-url]
+
 [stable-img]: https://img.shields.io/badge/stability-2%20--%20stable-brightgreen.svg?style=flat-square
 [stability-url]: https://iojs.org/api/documentation.html#documentation_stability_index
 ```
 ## Stability: 3 - Locked
 
 [![locked][locked-img]][stability-url]
+
 [locked-img]: https://img.shields.io/badge/stability-3%20--%20locked-blue.svg?style=flat-square
 
 ```md
 [![locked][locked-img]][stability-url]
+
 [locked-img]: https://img.shields.io/badge/stability-3%20--%20locked-blue.svg?style=flat-square
 [stability-url]: https://iojs.org/api/documentation.html#documentation_stability_index
 ```
-
 
 [stability-url]: https://iojs.org/api/documentation.html#documentation_stability_index


### PR DESCRIPTION
Update markdown so that it renders correctly with updated GFM (CommonMark).

Went to find this to copy it for a thing and noticed it's broken in the README.

@bcomnes what do you think of:

1. migrating this to hypermodules
2. renaming it to `stability-badges`

